### PR TITLE
FIX: it reports stats correctly about Jobs to NewRelic

### DIFF
--- a/newrelic_sidekiq_agent
+++ b/newrelic_sidekiq_agent
@@ -11,9 +11,9 @@ require 'redis'
 module NewRelic::Sidekiq
   class Agent < NewRelic::Plugin::Agent::Base
 
-    agent_guid 'com.eksoverzero.newrelic-sidekiq-agent'
+    agent_guid 'com.goodylabs.newrelic-sidekiq-agent'
     agent_config_options :name, :uri, :password, :namespace
-    agent_version '1.1.1'
+    agent_version '1.1.5'
     agent_human_labels('Sidekiq') { name }
 
     attr_reader :sidekiq_workers
@@ -48,7 +48,7 @@ module NewRelic::Sidekiq
       report_metric 'Jobs/Rate/Processed',  'Jobs/sec', @jobs_processed.process(sidekiq_stats.processed || 0)
       report_metric 'Jobs/Rate/Failed',     'Jobs/sec', @jobs_failed.process(sidekiq_stats.failed || 0)
 
-      stats.queues.each do |name, enqueued|
+      sidekiq_stats.queues.each do |name, enqueued|
         report_metric "Queues/#{name}", 'Enqueued',  enqueued || 0
         report_metric "Queues/#{name}", 'Latency',   Sidekiq::Queue.new(name).latency || 0
       end


### PR DESCRIPTION
no stacktrace like:

ERROR: Error occurred in poll cycle: NameError: undefined local variable or method `stats' for #<NewRelic::Sidekiq::Agent:0x000000025f7330>
DEBUG: Stacktrace:
./newrelic_sidekiq_agent:62:in `rescue in poll_cycle'
./newrelic_sidekiq_agent:43:in `poll_cycle'